### PR TITLE
feat: Add github dp loader javascript project

### DIFF
--- a/webDev/github-api-calls-axios/index.html
+++ b/webDev/github-api-calls-axios/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <title>Github API Calls With Axios</title>
+</head>
+
+<body>
+    <div id="root">
+        <form action="" id="myform">
+            <input id="username" name="username" placeholder="Github username">
+            <button>Submit</button>
+        </form>
+        <img id="mypic" />
+    </div>
+    <script>
+        let myform = document.getElementById("myform");
+        let pic = document.getElementById("mypic");
+        let username = document.getElementById("username");
+
+        myform.onsubmit = function (e) {
+            e.preventDefault();
+            let data = username.value;
+            // console.log(data);
+            /*
+            When data would be fetched over the network successfully, then only call the function
+            i.e. jab tak promise resolve nahi hua, tab tak baaki kaam karte reh sakte ho
+            */
+            axios.get("https://api.github.com/users/" + data).then(function (response) {
+                // console.log(response.data.avatar_url);
+                pic.setAttribute("src", response.data.avatar_url);
+            })
+        }
+    </script>
+</body>
+
+</html>

--- a/webDev/readme.md
+++ b/webDev/readme.md
@@ -1,1 +1,7 @@
 # Web Development related project
+
+<h3><b>1. Github DP Loader</b></h3>
+
+Small project made using javascript which shows github dp on entering github username in the input field. Made with [Axios](https://axios-http.com/) which helps in calling the github API enabling us to fetch user data including the url of their dp which is then shown on the screen.
+
+![Github API Calls With Axios video](https://user-images.githubusercontent.com/56643117/135519622-394625e9-0e97-40e7-95d6-29b8a90bd498.gif)


### PR DESCRIPTION
Small project made using javascript which shows github dp on entering github username in the input field. Made with [Axios](https://axios-http.com/) which helps in calling the github API enabling us to fetch user data including the url of their dp which is then shown on the screen.

> Trying my hands on open source by creating a Pull Request for Hacktober Fest 2021. 